### PR TITLE
Fixes for ResponsiveViews

### DIFF
--- a/mods/ResponsiveViews/scripts.js
+++ b/mods/ResponsiveViews/scripts.js
@@ -24,3 +24,6 @@ window.addEventListener("resize", debounce(() => {
         }
     }
 }, 20));
+
+// Call the resize event on page load, to apply current screen width
+window.dispatchEvent(new Event('resize'));

--- a/mods/ResponsiveViews/styles.css
+++ b/mods/ResponsiveViews/styles.css
@@ -1,5 +1,3 @@
-@media only screen and (max-width: 1024px) {
-    button[name="view"] {
-        display: none;
-    }
+button[name="view"] {
+    display: none;
 }


### PR DESCRIPTION
There's an issue where different screen widths call the resize event, and others don't on page load, these changes make the resize event fire on page load for all sizes, it also hides the view button (since it reloads the page, essentially not working anymore).